### PR TITLE
defined global.process in vite config file

### DIFF
--- a/src/lib/header/Header.svelte
+++ b/src/lib/header/Header.svelte
@@ -11,9 +11,7 @@
 			<img src={logo} alt="App Logo" />
 		</span>
 	</div>
-  <script>
-    var global = global || window;
-  </script>
+
 
 	<nav>
 		<svg viewBox="0 0 2 3" aria-hidden="true">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,5 @@ export default defineConfig({
 		sourcemap: 'inline' // helpful for debugging, maybe remove in production
 	}, 
 	define: { 
-		'global.process':  JSON.stringify('window.process')
 	}
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,8 @@ export default defineConfig({
 	},
 	build: {
 		sourcemap: 'inline' // helpful for debugging, maybe remove in production
-	},
-  global: {}
+	}, 
+	define: { 
+		'global.process':  JSON.stringify('window.process')
+	}
 });


### PR DESCRIPTION
Before this, npm run build was giving error when validateEvent was run which internally used global.process, which came as undefined ( and no events were fetched) .

Now it runs, and fetches events.