### PR TITLE
fix: patch buffer-es and remove esno

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"format": "prettier --write --plugin-search-dir=. .",
-		"postinstall": "esno scripts/patch.ts"
+		"postinstall": "node scripts/patch.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.25.2",
@@ -26,7 +26,6 @@
 		"eslint": "^8.23.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte3": "^4.0.0",
-		"esno": "^0.16.3",
 		"prettier": "^2.7.1",
 		"prettier-plugin-svelte": "^2.7.0",
 		"svelte": "^3.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ specifiers:
   eslint: ^8.23.0
   eslint-config-prettier: ^8.5.0
   eslint-plugin-svelte3: ^4.0.0
-  esno: ^0.16.3
   events: ^3.3.0
   marked: ^4.1.0
   nostr-tools: ^0.24.1
@@ -61,7 +60,6 @@ devDependencies:
   eslint: 8.23.0
   eslint-config-prettier: 8.5.0_eslint@8.23.0
   eslint-plugin-svelte3: 4.0.0_jtvgu4usxe4xoavzb5jpyaoyje
-  esno: 0.16.3
   prettier: 2.7.1
   prettier-plugin-svelte: 2.7.0_nk6d2fkgcllkkdynqbuearcure
   svelte: 3.50.1
@@ -1241,27 +1239,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
-    dev: true
-
-  /@esbuild-kit/cjs-loader/2.3.3:
-    resolution: {integrity: sha512-Rt4O1mXlPEDVxvjsHLgbtHVdUXYK9C1/6ThpQnt7FaXIjUOsI6qhHYMgALhNnlIMZffag44lXd6Dqgx3xALbpQ==}
-    dependencies:
-      '@esbuild-kit/core-utils': 2.3.0
-      get-tsconfig: 4.2.0
-    dev: true
-
-  /@esbuild-kit/core-utils/2.3.0:
-    resolution: {integrity: sha512-JL73zt/LN/qqziHuod4/bM2xBNNofDZu1cbwT6KIn6B11lA4cgDXkoSHOfNCbZMZOnh0Aqf0vW/gNQC+Z18hKQ==}
-    dependencies:
-      esbuild: 0.15.7
-      source-map-support: 0.5.21
-    dev: true
-
-  /@esbuild-kit/esm-loader/2.4.2:
-    resolution: {integrity: sha512-N9dPKAj8WOx6djVnStgILWXip4fjDcBk9L7azO0/uQDpu8Ee0eaL78mkN4Acid9BzvNAKWwdYXFJZnsVahNEew==}
-    dependencies:
-      '@esbuild-kit/core-utils': 2.3.0
-      get-tsconfig: 4.2.0
     dev: true
 
   /@esbuild-plugins/node-globals-polyfill/0.1.1_esbuild@0.15.7:
@@ -2613,13 +2590,6 @@ packages:
       - supports-color
     dev: true
 
-  /esno/0.16.3:
-    resolution: {integrity: sha512-6slSBEV1lMKcX13DBifvnDFpNno5WXhw4j/ff7RI0y51BZiDqEe5dNhhjhIQ3iCOQuzsm2MbVzmwqbN78BBhPg==}
-    hasBin: true
-    dependencies:
-      tsx: 3.9.0
-    dev: true
-
   /espree/9.4.0:
     resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2839,10 +2809,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.3
-    dev: true
-
-  /get-tsconfig/4.2.0:
-    resolution: {integrity: sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==}
     dev: true
 
   /glob-parent/5.1.2:
@@ -4227,17 +4193,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.8.3
-    dev: true
-
-  /tsx/3.9.0:
-    resolution: {integrity: sha512-ofxsE+qjqCYYq4UBt5khglvb+ESgxef1YpuNcdQI92kvcAT2tZVrnSK3g4bRXTUhLmKHcC5q8vIZA47os/stng==}
-    hasBin: true
-    dependencies:
-      '@esbuild-kit/cjs-loader': 2.3.3
-      '@esbuild-kit/core-utils': 2.3.0
-      '@esbuild-kit/esm-loader': 2.4.2
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /type-check/0.4.0:

--- a/scripts/patch.mjs
+++ b/scripts/patch.mjs
@@ -5,7 +5,7 @@ once fixed, we can remove this patch:
 https://github.com/nodejs/readable-stream/issues/487
 */
 const patchReadableStream = () => {
-	let content: string = readFileSync('./node_modules/readable-stream/lib/_stream_readable.js', {
+	let content = readFileSync('./node_modules/readable-stream/lib/_stream_readable.js', {
 		encoding: 'utf-8'
 	});
 	if (content.includes('global.Uint8Array')) {
@@ -38,6 +38,16 @@ const patchReadableStream = () => {
 		writeFileSync(
 			'./node_modules/rollup-plugin-node-polyfills/polyfills/util.js',
 			content.replace('if (isUndefined(global.process)) {', 'if (isUndefined(self.process)) {'),
+			{ encoding: 'utf-8' }
+		);
+	}
+	content = readFileSync('./node_modules/rollup-plugin-node-polyfills/polyfills/buffer-es6.js', {
+		encoding: 'utf-8'
+	});
+	if (content.includes('global.TYPED_ARRAY_SUPPORT')) {
+		writeFileSync(
+			'./node_modules/rollup-plugin-node-polyfills/polyfills/buffer-es6.js',
+			content.replace(/global\.TYPED_ARRAY_SUPPORT/g, 'self.TYPED_ARRAY_SUPPORT'),
 			{ encoding: 'utf-8' }
 		);
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
 	optimizeDeps: {
 		include: [
 			'nostr-tools > create-hash',
-			'nostr-tools > create-hmac',
 			'workbox-precaching',
 			'workbox-routing',
 			'workbox-window'


### PR DESCRIPTION
This PR includes:
- patch buffer-es polyfill: using global
- remove esno and use node to run `scripts/patch.mjs`
- remove `nostr-tools > create-hmac` from `optimizeDeps.include`